### PR TITLE
bluetooth and hal microservice creation fix on fog update

### DIFF
--- a/src/services/iofog-service.js
+++ b/src/services/iofog-service.js
@@ -174,7 +174,7 @@ async function _updateFog(fogData, user, isCli, transaction) {
       iofogUuid: fogData.uuid,
       rootHostAccess: true,
       logSize: 50,
-      userId: user.id,
+      userId: isCli ? oldFog.userId : user.id,
       configLastUpdated: Date.now()
     };
 
@@ -206,7 +206,7 @@ async function _updateFog(fogData, user, isCli, transaction) {
       iofogUuid: fogData.uuid,
       rootHostAccess: true,
       logSize: 50,
-      userId: user.id,
+      userId: isCli ? oldFog.userId : user.id,
       configLastUpdated: Date.now()
     };
 


### PR DESCRIPTION
if trying to update fog from cli then userId for bluetooth or hal microservices got from oldFog data instead of user obj, which doesn't exists in cli call