### PR TITLE
fix(iofog): add validation for version command

### DIFF
--- a/src/helpers/error-messages.js
+++ b/src/helpers/error-messages.js
@@ -73,6 +73,6 @@ module.exports = {
     INVALID_ROUTE: 'Route parsing error. Please provide valid route.'
   },
   CONNECTOR_IS_IN_USE: 'You can\'t delete connector, because it is used for routing now.',
-  INVALID_VERSION_COMMAND_UPGRADE: 'Can\'t upgrade version now. Latest already installed',
-  INVALID_VERSION_COMMAND_ROLLBACK: 'Can\'t rollback version now. There is no backups on agent'
+  INVALID_VERSION_COMMAND_UPGRADE: 'Can\'t upgrade version now. Latest is already installed',
+  INVALID_VERSION_COMMAND_ROLLBACK: 'Can\'t rollback version now. There are no backups on agent'
 };

--- a/src/helpers/error-messages.js
+++ b/src/helpers/error-messages.js
@@ -73,5 +73,6 @@ module.exports = {
     INVALID_ROUTE: 'Route parsing error. Please provide valid route.'
   },
   CONNECTOR_IS_IN_USE: 'You can\'t delete connector, because it is used for routing now.',
-  INVALID_VERSION_COMMAND: 'Can\'t {} version now.'
+  INVALID_VERSION_COMMAND_UPGRADE: 'Can\'t upgrade version now. Latest already installed',
+  INVALID_VERSION_COMMAND_ROLLBACK: 'Can\'t rollback version now. There is no backups on agent'
 };

--- a/src/services/iofog-service.js
+++ b/src/services/iofog-service.js
@@ -280,9 +280,11 @@ async function _setFogVersionCommand(fogVersionData, user, isCli, transaction) {
     throw new Errors.NotFoundError(AppHelper.formatMessage(ErrorMessages.INVALID_FOG_NODE_UUID, fogData.uuid))
   }
 
-  if ((!fog.isReadyToRollback && fogVersionData.versionCommand === 'rollback')
-    || (!fog.isReadyToUpgrade && fogVersionData.versionCommand === 'upgrade')) {
-    throw new Errors.ValidationError(AppHelper.formatMessage(ErrorMessages.INVALID_VERSION_COMMAND, fogVersionData.versionCommand))
+  if (!fog.isReadyToRollback && fogVersionData.versionCommand === 'rollback') {
+    throw new Errors.ValidationError(ErrorMessages.INVALID_VERSION_COMMAND_ROLLBACK)
+  }
+  if (!fog.isReadyToUpgrade && fogVersionData.versionCommand === 'upgrade') {
+    throw new Errors.ValidationError(ErrorMessages.INVALID_VERSION_COMMAND_UPGRADE)
   }
 
   await _generateProvisioningKey({uuid: fogVersionData.uuid}, user, isCli, transaction);


### PR DESCRIPTION
compare version command with isReadyToUpgrade and isReadyToRollback
fields

Closes EWC-448

<!--
********************************************************************************
IMPORTANT: make sure you don't forget to update any applicable documentation
in https://github.com/ioFog/iofog.org/tree/master/content/docs/next
********************************************************************************
Thank you for your contribution!
Code of Conduct: https://iofog.org/docs/contributing/code-of-conduct.html
-->

- Does the iofog.org or README.md documentation need to change?
  - [x] No

### Description

